### PR TITLE
fix params inside result

### DIFF
--- a/query.go
+++ b/query.go
@@ -78,15 +78,15 @@ type Status struct {
 }
 
 type Result struct {
-	Source           string           `json:"source"`
-	ResolvedQuery    string           `json:"resolvedQuery"`
-	Action           string           `json:"action"`
-	ActionIncomplete bool             `json:"actionIncomplete"`
-	Params           ContextParameter `json:"parameters"`
-	Contexts         []Context        `json:"contexts"`
-	Fulfillment      Fulfilment       `json:"fulfillment"`
-	Score            float64          `json:"score"`
-	Metadata         Metadata         `json:"metadata"`
+	Source           string            `json:"source"`
+	ResolvedQuery    string            `json:"resolvedQuery"`
+	Action           string            `json:"action"`
+	ActionIncomplete bool              `json:"actionIncomplete"`
+	Params           map[string]string `json:"parameters"`
+	Contexts         []Context         `json:"contexts"`
+	Fulfillment      Fulfilment        `json:"fulfillment"`
+	Score            float64           `json:"score"`
+	Metadata         Metadata          `json:"metadata"`
 }
 
 type QueryResponse struct {

--- a/query_test.go
+++ b/query_test.go
@@ -36,7 +36,9 @@ func TestQuery(t *testing.T) {
     "resolvedQuery": "my name is Marcos and I live in Barcelona",
     "action": "greetings",
     "actionIncomplete": false,
-    "parameters": {},
+		"parameters": {
+			"name": "Marcos",
+		},
     "contexts": [],
     "metadata": {
       "intentId": "a123a123",
@@ -69,6 +71,7 @@ func TestQuery(t *testing.T) {
 					Source:        "agent",
 					ResolvedQuery: "my name is Marcos and I live in Barcelona",
 					Action:        "greetings",
+					Params:        map[string]string{"name": "Marcos"},
 					Contexts:      []Context{},
 					Fulfillment: Fulfilment{
 						Speech: "Hi Marcos! Nice to meet you!",

--- a/query_test.go
+++ b/query_test.go
@@ -36,9 +36,7 @@ func TestQuery(t *testing.T) {
     "resolvedQuery": "my name is Marcos and I live in Barcelona",
     "action": "greetings",
     "actionIncomplete": false,
-		"parameters": {
-			"name": "Marcos",
-		},
+		"parameters": { "name": "Marcos" },
     "contexts": [],
     "metadata": {
       "intentId": "a123a123",


### PR DESCRIPTION
I found a bug in `Result` struct. Previously `Params` were using `ContextParameter` struct which was incorrect. After decoding, field was always empty (`parameters` is an object with dynamic keys – based on your entities that you defined on API.ai platform).

`map[string]string` instead solves the problem. (I also added it to tests).