### PR TITLE
fix CreateContext header

### DIFF
--- a/contexts.go
+++ b/contexts.go
@@ -22,7 +22,7 @@ func (c *ApiClient) GetContexts(sessionId string) ([]Context, error) {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-type", "application/json, charset=utf-8")
+	req.Header.Set("Content-type", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", "Bearer "+c.config.Token)
 
 	httpClient := http.DefaultClient
@@ -54,7 +54,7 @@ func (c *ApiClient) GetContext(name, sessionId string) (*Context, error) {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-type", "application/json, charset=utf-8")
+	req.Header.Set("Content-type", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", "Bearer "+c.config.Token)
 
 	httpClient := http.DefaultClient
@@ -92,7 +92,7 @@ func (c *ApiClient) CreateContext(context Context, sessionId string) error {
 		return err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-type", "application/json, charset=utf-8")
+	req.Header.Set("Content-type", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", "Bearer "+c.config.Token)
 
 	httpClient := http.DefaultClient
@@ -118,7 +118,7 @@ func (c *ApiClient) DeleteContexts(sessionId string) error {
 		return err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-type", "application/json, charset=utf-8")
+	req.Header.Set("Content-type", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", "Bearer "+c.config.Token)
 
 	httpClient := http.DefaultClient
@@ -144,7 +144,7 @@ func (c *ApiClient) DeleteContext(name, sessionId string) error {
 		return err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-type", "application/json, charset=utf-8")
+	req.Header.Set("Content-type", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", "Bearer "+c.config.Token)
 
 	httpClient := http.DefaultClient


### PR DESCRIPTION
## Intro:
api.ai allows users to get/set the context by using `/context` end point. Currently you can get it, reset it but you **can't** set it due to mistake in the code.

## Reason:

According to: https://www.w3.org/Protocols/rfc1341/4_Content-Type.html

Content-Type header field value is defined as follows:
```
Content-Type := type "/" subtype *[";" parameter]
                                    ^
```

## Solution:

Change `,` to `;`
