### PR TITLE
Message type might be int or str

### DIFF
--- a/query.go
+++ b/query.go
@@ -55,7 +55,7 @@ type Metadata struct {
 }
 
 type Message struct {
-	Type     int          `json:"type"`
+	Type     interface{}  `json:"type"`
 	Speech   string       `json:"speech"`
 	ImageUrl string       `json:"imageUrl"`
 	Title    string       `json:"title"`


### PR DESCRIPTION
This fixes a problem where unmarshalling when the Type in Message is transmitted as a string