### PR TITLE
fix context params / add+improve tests

### DIFF
--- a/contexts.go
+++ b/contexts.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Context struct {
-	Name     string            `json:"name"`
-	Lifespan int               `json:"lifespan"`
-	Params   map[string]string `json:"parameters"`
+	Name     string                 `json:"name"`
+	Lifespan int                    `json:"lifespan"`
+	Params   map[string]interface{} `json:"parameters"`
 }
 
 func (c *ApiClient) GetContexts(sessionId string) ([]Context, error) {

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -28,31 +28,39 @@ func TestGetContexts(t *testing.T) {
 		{
 			description: "api ai success, no errors",
 			responder: httpmock.NewStringResponder(200, `[
-{
- "name": "Play game",
- "parameters": {
-  "any": "value",
-  "number": "1"
- }
-},
-{
- "name": "Coffee time",
- "parameters": {
-  "temperature": "cold"
- }
-}
-]`),
+			{
+				"name": "Play game",
+				"parameters": {
+					"any": "value",
+					"number": 1.5,
+					"duration": {
+						"amount": 30.0,
+						"units": "min"
+					}
+				}
+			},
+			{
+				"name": "Coffee time",
+				"parameters": {
+					"temperature": "cold"
+				}
+			}
+			]`),
 			expectedResponse: []Context{
 				{
 					Name: "Play game",
-					Params: map[string]string{
+					Params: map[string]interface{}{
 						"any":    "value",
-						"number": "1",
+						"number": 1.5,
+						"duration": map[string]interface{}{
+							"amount": 30.0,
+							"units":  "min",
+						},
 					},
 				},
 				{
 					Name: "Coffee time",
-					Params: map[string]string{
+					Params: map[string]interface{}{
 						"temperature": "cold",
 					},
 				},
@@ -98,17 +106,17 @@ func TestGetContext(t *testing.T) {
 		{
 			description: "api ai success, no errors",
 			responder: httpmock.NewStringResponder(200, `{
-  "name": "Coffee time",
-  "parameters": {
-   "type-1": "long",
-   "type-2": "short",
-   "temperature-1": "hot",
-   "temperature-2": "cold"
-  }
-}`),
+				"name": "Coffee time",
+				"parameters": {
+					"type-1": "long",
+					"type-2": "short",
+					"temperature-1": "hot",
+					"temperature-2": "cold"
+				}
+			}`),
 			expectedResponse: &Context{
 				Name: "Coffee time",
-				Params: map[string]string{
+				Params: map[string]interface{}{
 					"type-1":        "long",
 					"type-2":        "short",
 					"temperature-1": "hot",
@@ -171,7 +179,7 @@ func TestCreateContext(t *testing.T) {
 
 		err := c.CreateContext(Context{
 			Name: "Coffee time",
-			Params: map[string]string{
+			Params: map[string]interface{}{
 				"type-1":        "long",
 				"type-2":        "short",
 				"temperature-1": "hot",


### PR DESCRIPTION
## Intro:
Recently you merged PR (https://github.com/marcossegovia/apiai-go/pull/6) which solved the problem with params (as a list). It also solved the problem with "duration" entity which is available on api.ai. However when your intent has to be fulfilled (params like `duration` is marked as required) they will be visible not as `Results->Params` but also as `Results->Contexts->Params`. 

Example from api.ai
```
{
  "id": "xxx",
  ...
  "result": {
    "source": "agent",
    "resolvedQuery": "30min",
    "action": "calendar.meeting",
    "actionIncomplete": true,
    "parameters": {
      "attendees": "@rafal",
      "date": "",
      "duration": {
        "amount": 30,
        "unit": "min"
      },
      "summary": "test",
      "time": ""
    },
    "contexts": [
      {
        "name": "calendar_meeting_dialog_context",
        "parameters": {
          "summary": "test",
          "duration": {
            "amount": 30,
            "unit": "min"
          },
          "date": "",
          "time.original": "",
          "date.original": "",
          "attendees.original": "@rafal",
          "attendees": "@rafal",
          "summary.original": "test",
          "time": "",
          "duration.original": "30min"
        },
        "lifespan": 2
      },
     ...
  }
}
```

## Solution:
switch to `map[string]interface{}`

## Extra
I also fixed formatting of the mock (my editor was forcing me to do it). Tests has been updated as well.